### PR TITLE
fix: error getting pid in php7

### DIFF
--- a/DaemonController.php
+++ b/DaemonController.php
@@ -318,11 +318,11 @@ abstract class DaemonController extends Controller
     /**
      * PCNTL signals handler
      *
-     * @param $signo
-     * @param null $pid
+     * @param int   $signo
+     * @param array $siginfo
      * @param null $status
      */
-    final static function signalHandler($signo, $pid = null, $status = null)
+    final static function signalHandler($signo, $siginfo = [], $status = null)
     {
         switch ($signo) {
             case SIGINT:
@@ -337,6 +337,7 @@ abstract class DaemonController extends Controller
                 //user signal, not implemented
                 break;
             case SIGCHLD:
+                $pid = $siginfo['pid'] ?? null;
                 if (!$pid) {
                     $pid = pcntl_waitpid(-1, $status, WNOHANG);
                 }


### PR DESCRIPTION
Fix the error of getting pid in php7, the second parameter of the pcntl_signal function in the callback should be siginfo array

修复在php7中 获取 pid 的错误，pcntl_signal函数在回调的时候第二参数应该是 siginfo 数组

Ps:  https://github.com/php/php-src/blob/master/ext/pcntl/tests/pcntl_realtime_signal.phpt
